### PR TITLE
Refine mobile notification button layout on mobile

### DIFF
--- a/components/notification_types/contract-create/con-vremya2.vue
+++ b/components/notification_types/contract-create/con-vremya2.vue
@@ -18,12 +18,12 @@
                 item.ccopmany }}</b> tomonidan qabul
             qilinmaganligi sababli tizim tomonidan rad etildi.
           </p>
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -49,12 +49,12 @@
             tomonidan rad etildi.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -81,12 +81,12 @@
                 item.ccopmany }}</b>
             томонидан қабул қилинмаганлиги сабабли тизим томонидан рад қилинди.
           </p>
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -110,12 +110,12 @@
             қилинмаганлиги сабабли тизим томонидан рад қилинди.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -138,12 +138,12 @@
               target="_blank"><b>{{ item.number }}</b></a> до 23:59 {{ item.created }} г. Поэтому этот договор
             займа был автоматически отклонен системой.
           </p>
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -166,12 +166,12 @@
               item.created }} г.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>

--- a/components/notification_types/contract-create/contract-accept.vue
+++ b/components/notification_types/contract-create/contract-accept.vue
@@ -39,12 +39,12 @@
             {{ item.currency }}</b>
           miqdorida qarz oldingiz.
         </div>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -69,12 +69,12 @@
             {{ item.currency }}</b>
           miqdorida qarz berdingiz.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -115,12 +115,12 @@
               item.dcompany }}</b>дан <b>{{ item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") }}
             {{ item.currency }}</b> миқдорида қарз олдингиз.
         </div>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -143,12 +143,12 @@
               item.ccopmany }}</b>га <b>{{ item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") }}
             {{ item.currency }}</b> миқдорида қарз бердингиз.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -173,12 +173,12 @@
           <span v-if="item.token != null">С Вашего счета списано <b> {{
             item.token.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") }} UZS</b> в качестве платы за услугу.</span>
         </div>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -202,12 +202,12 @@
             {{ item.currency }}</b>.
 
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/contract-create/contract-create.vue
+++ b/components/notification_types/contract-create/contract-create.vue
@@ -18,12 +18,12 @@
             target="_blank"><b>{{
               item.number }}</b></a>-sonli qarz shartnomasi rasmiylashtiriladi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <a :href="`https://pdf.zerox.uz/index.php?id=${item.uid}&lang=${$i18n.locale}&download=0`"
               target="_blank"><button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 {{ $t("comp.full") }}
@@ -75,12 +75,12 @@
             target="_blank"><b>{{
               item.number }}</b></a>-sonli qarz shartnomasi rasmiylashtiriladi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <a :href="`https://pdf.zerox.uz/index.php?id=${item.uid}&lang=${$i18n.locale}&download=0`"
               target="_blank"><button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 {{ $t("comp.full") }}
@@ -114,12 +114,12 @@
             target="_blank"><b>{{ item.number
               }}</b></a>-сонли қарз шартномаси расмийлаштирилади.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <a :href="`https://pdf.zerox.uz/index.php?id=${item.uid}&lang=${$i18n.locale}&download=0`"
               target="_blank"><button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 {{ $t("comp.full") }}
@@ -167,12 +167,12 @@
             target="_blank"><b>{{
               item.number }}</b></a>-сонли қарз шартномаси расмийлаштирилади.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <a :href="`https://pdf.zerox.uz/index.php?id=${item.uid}&lang=${$i18n.locale}&download=0`"
               target="_blank"><button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 {{ $t("comp.full") }}
@@ -205,12 +205,12 @@
             target="_blank"><b>{{ item.number
               }}</b></a>.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <a :href="`https://pdf.zerox.uz/index.php?id=${item.uid}&lang=${$i18n.locale}&download=0`"
               target="_blank"><button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 {{ $t("comp.full") }}
@@ -255,12 +255,12 @@
             target="_blank"><b>{{
               item.number }}</b></a>.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <a :href="`https://pdf.zerox.uz/index.php?id=${item.uid}&lang=${$i18n.locale}&download=0`"
               target="_blank"><button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 {{ $t("comp.full") }}

--- a/components/notification_types/contract-create/contract-my-reject.vue
+++ b/components/notification_types/contract-create/contract-my-reject.vue
@@ -14,14 +14,14 @@
         miqdorida qarz berish to‘g‘risidagi shartnoma belgilangan muddat
         davomida qabul qilinmadi.</p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span
               ><b>{{ $t("comp.time") }}:</b>
                {{ item.created }} {{item?.time.slice(0,5)}}</span
             >
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button
               @click="ok(item.id)"
               class="bg-blue-500 py-1 px-4 mx-2 rounded text-white"
@@ -45,14 +45,14 @@
         miqdorida qarz olish to‘g‘risidagi shartnoma belgilangan muddat davomida
         qabul qilinmadi.</p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span
               ><b>{{ $t("comp.time") }}:</b>
                {{ item.created }} {{item?.time.slice(0,5)}}</span
             >
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button
               @click="ok(item.id)"
               class="bg-blue-500 py-1 px-4 mx-2 rounded text-white"

--- a/components/notification_types/contract-create/contract-reject.vue
+++ b/components/notification_types/contract-create/contract-reject.vue
@@ -13,12 +13,12 @@
             {{ item.currency }}</b>
           miqdorida qarz berish to‘g‘risidagi shartnoma rad qilindi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -38,12 +38,12 @@
           miqdorida qarz olish to‘g‘risidagi shartnoma rad qilindi.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -64,12 +64,12 @@
             {{ item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") }}
             {{ item.currency }}</b> миқдорида қарз бериш тўғрисидаги шартнома рад қилинди.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -88,12 +88,12 @@
             {{ item.currency }}</b> миқдорида қарз олиш тўғрисидаги шартнома рад қилинди.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -113,12 +113,12 @@
             {{ item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") }}
             {{ item.currency }}</b>.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -137,12 +137,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/contract-create/contract-vremya.vue
+++ b/components/notification_types/contract-create/contract-vremya.vue
@@ -14,11 +14,11 @@
           ga qadar
           Siz tomoningizdan qabul qilinmaganligi sababli tizim tomonidan rad qilindi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -40,11 +40,11 @@
             getFullName('sender')
           }}</b> tomonidan qabul qilinmaganligi sababli tizim tomonidan rad qilindi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -65,11 +65,11 @@
           юборилган. Ушбу қарз шартномаси {{ item.created }} йил соат 23:59 га қадар Сиз томонингиздан қабул
           қилинмаганлиги сабабли тизим томонидан рад қилинди.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -90,11 +90,11 @@
             getFullName('sender')
           }}</b> томонидан қабул қилинмаганлиги сабабли тизим томонидан рад қилинди.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -117,11 +117,11 @@
           Однако этот договор займа был автоматически отклонен системой в связи с тем, что Вы не приняли его до 23:59
           {{ item.created }} г.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -140,11 +140,11 @@
             target="_blank"><b>{{ item.number }}</b></a> до 23:59 {{ item.created }} г. Поэтому этот
           договор займа был автоматически отклонен системой.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/contract-create/delete-act.vue
+++ b/components/notification_types/contract-create/delete-act.vue
@@ -27,12 +27,12 @@
           bekor qilindi.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -61,12 +61,12 @@
           qilinmaganligi sababli tizim tomonidan bekor qilindi. Qayta so‘rov
           yuborishingiz mumkin.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -100,12 +100,12 @@
           бекор қилинди.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -134,12 +134,12 @@
           қилинмаганлиги сабабли тизим томонидан бекор қилинди. Қайта сўров
           юборишингиз мумкин.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -167,12 +167,12 @@
           повторно.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -198,12 +198,12 @@
             Однако Вы не приняли этот запрос до 23:59 <b>{{ item.created }} г.</b>  Поэтому этот запрос был автоматически отклонен системой.
 
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/debt-demand.vue
+++ b/components/notification_types/debt-demand.vue
@@ -19,12 +19,12 @@
           talab qilmoqda.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="redirectNotification(item.id, item.contract)"
               class="bg-blue-500 py-1 px-4 rounded text-white">
               {{ $t("list.return") }}
@@ -55,12 +55,12 @@
             {{ item.currency }}</b> қарзни қайтаришингизни талаб қилмоқда.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="redirectNotification(item.id, item.contract)"
               class="bg-blue-500 py-1 px-4 rounded text-white">
               {{ $t("list.return") }}
@@ -91,12 +91,12 @@
               }}</b></a> от {{ item.created_at }} г.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="redirectNotification(item.id, item.contract)"
               class="bg-blue-500 py-1 px-4 rounded text-white">
               {{ $t("list.return") }}

--- a/components/notification_types/debt-extend/debt-extend-result.vue
+++ b/components/notification_types/debt-extend/debt-extend-result.vue
@@ -17,12 +17,12 @@
             <b>{{ dateFormat(item.end_date) }}</b> yilga qadar uzaytirildi.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -44,12 +44,12 @@
             <b>{{ dateFormat(item.end_date) }}</b> yilga qadar uzaytirildi.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -74,12 +74,12 @@
             қадар узайтирилди.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -100,12 +100,12 @@
             <b>{{ dateFormat(item.end_date) }}</b> йилга қадар узайтирилди.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -129,12 +129,12 @@
                 item.number }}</b></a> до <b>{{ dateFormat(item.end_date) }}</b> г.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -155,12 +155,12 @@
                 item.number }}</b></a> до <b>{{ dateFormat(item.end_date) }}</b> г.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -189,12 +189,12 @@
             uzaytirish to‘g‘risidagi so‘rovnomangiz rad etildi.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -219,12 +219,12 @@
             сўровномангиз рад этилди.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>
@@ -247,12 +247,12 @@
                 item.number }}</b></a> от {{ item.created_at }} г.
           </p>
 
-          <div class="flex justify-between mt-4">
+          <div class="notification-actions">
             <div>
               <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
                 {{ item?.time.slice(0, 5) }}</span>
             </div>
-            <div>
+            <div class="notification-actions__buttons">
               <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
                 Ok
               </button>

--- a/components/notification_types/debt-extend/debt-extend.vue
+++ b/components/notification_types/debt-extend/debt-extend.vue
@@ -17,12 +17,12 @@
           <b>{{ dateFormat(item.end_date) }}</b> yilgacha uzaytirishingizni so‘ramoqda.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="muddatUzaytirishQabul(item.id, 1)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               {{ $t("process.accept") }}
             </button>
@@ -49,12 +49,12 @@
           <b>{{ dateFormat(item.end_date) }}</b> yilga qadar uzaytirildi.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="muddatUzaytirishQabul(item.id, 1)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               {{ $t("process.accept") }}
             </button>
@@ -83,12 +83,12 @@
           <b>{{ dateFormat(item.end_date) }}</b> йилгача узайтиришингизни сўрамоқда.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="muddatUzaytirishQabul(item.id, 1)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               {{ $t("process.accept") }}
             </button>
@@ -115,12 +115,12 @@
           <b>{{ dateFormat(item.end_date) }}</b> йилга қадар узайтирилди.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="muddatUzaytirishQabul(item.id, 1)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               {{ $t("process.accept") }}
             </button>
@@ -147,12 +147,12 @@
               }}</b></a> от {{ item.created_at }} г. до <b>{{ dateFormat(item.end_date) }} г</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="muddatUzaytirishQabul(item.id, 1)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               {{ $t("process.accept") }}
             </button>
@@ -179,12 +179,12 @@
               }} г</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="muddatUzaytirishQabul(item.id, 1)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               {{ $t("process.accept") }}
             </button>

--- a/components/notification_types/debt-refund/debt-fullRefund-result/debt-fullRefund-accept.vue
+++ b/components/notification_types/debt-refund/debt-fullRefund-result/debt-fullRefund-accept.vue
@@ -22,12 +22,12 @@
           {{ item.currency }}.</b>
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>
@@ -55,12 +55,12 @@
           {{ item.currency }} </b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>
@@ -86,12 +86,12 @@
           {{ item.currency }} </b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>

--- a/components/notification_types/debt-refund/debt-fullRefund-result/debt-fullRefund-reject.vue
+++ b/components/notification_types/debt-refund/debt-fullRefund-result/debt-fullRefund-reject.vue
@@ -13,12 +13,12 @@
           so`rovnomangiz rad qilindi.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -48,12 +48,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -75,12 +75,12 @@
           сўровномангиз рад қилинди.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -108,12 +108,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -135,12 +135,12 @@
           so`rovnomangiz rad qilindi.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -168,12 +168,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/debt-refund/debt-partialRefund/debt-partialRefund-accept.vue
+++ b/components/notification_types/debt-refund/debt-partialRefund/debt-partialRefund-accept.vue
@@ -22,12 +22,12 @@
           {{ item.currency }}</b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b>  {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>
@@ -55,12 +55,12 @@
           {{ item.currency }}</b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b>  {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>
@@ -89,12 +89,12 @@
 
 
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b>  {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>

--- a/components/notification_types/debt-refund/debt-partialRefund/debt-partialRefund-reject.vue
+++ b/components/notification_types/debt-refund/debt-partialRefund/debt-partialRefund-reject.vue
@@ -22,12 +22,12 @@
           {{ item.currency }}</b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>
@@ -55,12 +55,12 @@
           {{ item.currency }}</b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>
@@ -87,12 +87,12 @@
           {{ item.currency }}</b>.
       </p>
 
-      <div class="flex justify-between mt-4">
+      <div class="notification-actions">
         <div>
           <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
             {{ item?.time.slice(0, 5) }}</span>
         </div>
-        <div>
+        <div class="notification-actions__buttons">
           <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
             Ok
           </button>

--- a/components/notification_types/debt-refund/debt-refund.vue
+++ b/components/notification_types/debt-refund/debt-refund.vue
@@ -28,12 +28,12 @@
             {{ item.currency }}</b>.
         </p>
         <!--  -->
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button v-if="item.residual_amount != 0" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white"
               @click="qismanQaytarish(item.id, 1)">
               {{ $t("process.accept") }}
@@ -78,12 +78,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="fullReturn(item.id, 1)">
               {{ $t("process.accept") }}
             </button>
@@ -118,12 +118,12 @@
         }}
           {{ item.currency }}</b>.
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button v-if="item.residual_amount != 0" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white"
               @click="qismanQaytarish(item.id, 1)">
               {{ $t("process.accept") }}
@@ -162,12 +162,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="fullReturn(item.id, 1)">
               {{ $t("process.accept") }}
             </button>
@@ -204,12 +204,12 @@
             .replace(/\B(?=(\d{3})+(?!\d))/g, " ")
         }}
           {{ item.currency }}</b>.
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button v-if="item.residual_amount != 0" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white"
               @click="qismanQaytarish(item.id, 1)">
               {{ $t("process.accept") }}
@@ -249,12 +249,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="fullReturn(item.id, 1)">
               {{ $t("process.accept") }}
             </button>

--- a/components/notification_types/debt-waiver/debt-fullWaiver.vue
+++ b/components/notification_types/debt-waiver/debt-fullWaiver.vue
@@ -24,12 +24,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -59,12 +59,12 @@
             {{ item.currency }}</b>.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -93,12 +93,12 @@
             item.created_at }} г.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/ex-time.vue
+++ b/components/notification_types/ex-time.vue
@@ -14,12 +14,12 @@
             item.created }} yil soat 23:59 ga qadar qabul qilinmaganligi sababli
           tizim tomonidan bekor qilindi. Qayta so‘rov yuborishingiz mumkin.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -40,12 +40,12 @@
           yil 23:59 ga qadar qabul qilinmaganligi sababli tizim tomonidan bekor qilindi.
 
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -68,12 +68,12 @@
             item.created }} йил соат 23:59 га қадар қабул қилинмаганлиги сабабли тизим томонидан
           бекор қилинди. Қайта сўров юборишингиз мумкин.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -95,12 +95,12 @@
           23:59 га қадар қабул қилинмаганлиги сабабли тизим томонидан бекор қилинди.
 
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -125,12 +125,12 @@
           системой.
           Вы можете отправить запрос повторно.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -153,12 +153,12 @@
             item.created }} г.
 
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/infocom.vue
+++ b/components/notification_types/infocom.vue
@@ -11,12 +11,12 @@
           qilmasligingizni so‘raymiz.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -36,12 +36,12 @@
           сўраймиз.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -60,12 +60,12 @@
           Вас запомнить пароль для входа в систему и не раскрывать его другим лицам.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/infocom2.vue
+++ b/components/notification_types/infocom2.vue
@@ -13,12 +13,12 @@
           <b>2 500 UZS</b>
           yechildi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -39,12 +39,12 @@
           <b>2 500 UZS</b>
           ечилди.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -65,12 +65,12 @@
           <b>2 500 сум</b>
           решено.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/notification_5day.vue
+++ b/components/notification_types/notification_5day.vue
@@ -8,12 +8,12 @@
         <p class="mt-2">
           Sizda qaytarish muddati yaqinlashayotgan qarz shartnomalari mavjud.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
               Ko‘rish
             </button>
@@ -33,12 +33,12 @@
         <p class="mt-2">
           Сизда қайтариш муддати яқинлашаётган қарз шартномалари мавжуд.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
               Кўриш
             </button>
@@ -58,12 +58,12 @@
         <p class="mt-2">
           У вас есть договоры займа с приближающимся сроком погашения.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
               Просмотреть
             </button>

--- a/components/notification_types/passport.vue
+++ b/components/notification_types/passport.vue
@@ -10,12 +10,12 @@
                     funksiyalaridan foydalana olmaysiz. Iltimos, tizimdan to‘liq foydalanish uchun quyidagi havola
                     orqali mobil ilovani yuklab oling va qayta identifikatsiyadan o‘ting.
                 </p>
-                <div class="flex justify-between mt-4">
+                <div class="notification-actions">
                     <div>
                         <span><b>{{ $t("comp.time") }}:</b>
                             {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
                     </div>
-                    <div>
+                    <div class="notification-actions__buttons">
                         <!-- <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
                             Identifikatsiyadan o‘tish
                         </button> -->
@@ -37,12 +37,12 @@
                     функцияларидан фойдалана олмайсиз. Илтимос, тизимдан тўлиқ фойдаланиш учун қуйидаги ҳавола орқали
                     мобил иловани юклаб олинг ва қайта идентификациядан ўтинг.
                 </p>
-                <div class="flex justify-between mt-4">
+                <div class="notification-actions">
                     <div>
                         <span><b>{{ $t("comp.time") }}:</b>
                             {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
                     </div>
-                    <div>
+                    <div class="notification-actions__buttons">
                         <!-- <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
                             Идентификациядан ўтиш
                         </button> -->
@@ -62,12 +62,12 @@
                 <p class="mt-2">
                     Уважаемый пользователь, Вы не можете использовать основные функции системы, потому что срок действия вашей ID-карты (паспорта) истек. Пожалуйста, загрузите мобильное приложение по ссылке ниже и пройдите повторную идентификацию, чтобы в полной мере использовать систему.
                 </p>
-                <div class="flex justify-between mt-4">
+                <div class="notification-actions">
                     <div>
                         <span><b>{{ $t("comp.time") }}:</b>
                             {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
                     </div>
-                    <div>
+                    <div class="notification-actions__buttons">
                         <!-- <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
                             Пройти идентификацию
                         </button> -->

--- a/components/notification_types/request-user.vue
+++ b/components/notification_types/request-user.vue
@@ -11,12 +11,12 @@
           shartnomalaringiz bo‘yicha
           ma’lumotni ko‘rishga ruxsat so‘ramoqda.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
               Ruxsat berish
             </button>
@@ -38,12 +38,12 @@
             v-if="item.dtypes == 1">{{ item.dcompany }}</b> қарз
           шартномаларингиз бўйича маълумотни кўришга рухсат сўрамоқда.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
               Рухсат бериш
             </button>
@@ -65,12 +65,12 @@
             v-if="item.dtypes == 1">{{ item.dcompany }}</b>
           просит разрешение на просмотр данных по вашим долговым договорам.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button class="bg-blue-500 py-1 px-4 mx-2 rounded text-white" @click="update(item.id, 1)">
               Разрешить
             </button>

--- a/components/notification_types/savol.vue
+++ b/components/notification_types/savol.vue
@@ -9,12 +9,12 @@
           <b v-if="item.dtypes == 2">{{ item.d_last_name }} {{ item.d_first_name }} {{ item.d_middle_name }}</b><b v-if="item.dtypes == 1">{{ item.dcompany
             }}</b> qarz ma’lumotlarini ko‘rishga ruxsat bermadi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -31,12 +31,12 @@
           <b v-if="item.dtypes == 2">{{ item.d_last_name }} {{ item.d_first_name }} {{ item.d_middle_name }}</b><b v-if="item.dtypes == 1">{{ item.dcompany
             }}</b> қарз маълумотларини кўришга рухсат бермади.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -53,12 +53,12 @@
           <b v-if="item.dtypes == 2">{{ item.d_last_name }} {{ item.d_first_name }} {{ item.d_middle_name }}</b><b v-if="item.dtypes == 1">{{ item.dcompany
             }}</b> не разрешил(а) просмотреть данные о займах.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/savol2.vue
+++ b/components/notification_types/savol2.vue
@@ -10,12 +10,12 @@
             v-if="item.dtypes == 1">{{ item.dcompany
             }}</b> qarz ma’lumotlarini ko‘rishga ruxsat berdi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <!-- {{ item }} -->
             <button @click="sendUrl(item, item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ma’lumotlarni ko‘rish
@@ -38,12 +38,12 @@
             v-if="item.dtypes == 1">{{ item.dcompany
             }}</b> қарз маълумотларини кўришга рухсат берди.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <!-- {{ item }} -->
             <button @click="sendUrl(item, item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Маълумотларни кўриш
@@ -66,12 +66,12 @@
             v-if="item.dtypes == 1">{{ item.dcompany
             }}</b> разрешил(а) просмотреть данные о займах.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b>
               {{ item.created }} {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <!-- {{ item }} -->
             <button @click="sendUrl(item, item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Просмотреть данные

--- a/components/notification_types/transfer-money1.vue
+++ b/components/notification_types/transfer-money1.vue
@@ -15,12 +15,12 @@
           o‘tkazdingiz.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -43,12 +43,12 @@
             UZS</b> ўтказдингиз.
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -70,12 +70,12 @@
               item.c_first_name }} {{ item.c_middle_name }}</b><b v-if="item.ctypes == 1">{{ item.ccopmany }}</b>).
         </p>
 
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/components/notification_types/transfer-money2.vue
+++ b/components/notification_types/transfer-money2.vue
@@ -17,12 +17,12 @@
             UZS</b>
           miqdorida mablag‘ o‘tkazildi.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -46,12 +46,12 @@
           }}
             UZS</b> миқдорида маблағ ўтказилди.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>
@@ -75,12 +75,12 @@
           }}
             UZS</b>.
         </p>
-        <div class="flex justify-between mt-4">
+        <div class="notification-actions">
           <div>
             <span><b>{{ $t("comp.time") }}:</b> {{ item.created }}
               {{ item?.time.slice(0, 5) }}</span>
           </div>
-          <div>
+          <div class="notification-actions__buttons">
             <button @click="ok(item.id)" class="bg-blue-500 py-1 px-4 mx-2 rounded text-white">
               Ok
             </button>

--- a/styles/global.css
+++ b/styles/global.css
@@ -7,29 +7,21 @@ body {
     color : red !important;
 }
 
-@media (max-width: 640px) {
-    .notification-card .flex.justify-between.mt-4 {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1rem;
+@layer components {
+    .notification-actions {
+        @apply mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between;
     }
 
-    .notification-card .flex.justify-between.mt-4 > div:last-child {
-        width: 100%;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        justify-content: flex-start;
+    .notification-actions__buttons {
+        @apply w-full flex flex-wrap items-center gap-2 sm:w-auto sm:justify-end;
     }
 
-    .notification-card .flex.justify-between.mt-4 > div:last-child > * {
-        width: 100%;
-        margin-left: 0 !important;
-        margin-right: 0 !important;
+    .notification-actions__buttons > * {
+        @apply mx-0;
     }
 
-    .notification-card .flex.justify-between.mt-4 > div:last-child button,
-    .notification-card .flex.justify-between.mt-4 > div:last-child a button {
-        width: 100%;
+    .notification-actions__buttons button,
+    .notification-actions__buttons a button {
+        @apply w-auto;
     }
 }


### PR DESCRIPTION
## Summary
- add reusable Tailwind component classes to control notification action layout for mobile screens
- update all notification type components to use the new wrappers so action buttons stay on one row on small devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb815600b883268ecfae3c0f8fce83