### PR TITLE
Adjust mobile layouts and navigation

### DIFF
--- a/components/NavbarLogged.vue
+++ b/components/NavbarLogged.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="nav media-nava max-h-[600px] px-6 w-[400px] rounded-xl bg-white">
+  <div
+    class="nav media-nava max-h-[600px] px-6 w-full max-w-[320px] sm:max-w-[360px] md:w-[400px] md:max-w-none rounded-r-2xl md:rounded-xl bg-white shadow-xl md:shadow-none"
+  >
     <div>
-      <div class="px-2 pt-3.5 rounded-xl bg-white" style="width: 300px">
+      <div class="px-2 pt-3.5 rounded-xl bg-white w-full">
         <div class="flex justify-between">
           <nuxt-link :to="localePath({ name: 'index' })" @click="$store.commit('Media_Menu_Close', false)"
             class="flex justify-center mx-auto cursor-pointer items-center flex-col mb-3.5">
@@ -20,7 +22,53 @@
           </h2>
         </div>
 
-        <hr />
+        <hr class="border-gray-100" />
+
+        <nuxt-link v-if="$auth.loggedIn" :to="localePath({ name: 'mobil-hisob' })" class="md:hidden block">
+          <div
+            @click="$store.commit('Media_Menu_Close', false)"
+            class="mt-4 rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 shadow-sm"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <p class="text-[11px] font-medium uppercase tracking-wide text-blue-700">
+                  {{ $t('navbar.mobile') }}
+                </p>
+                <p class="text-lg font-semibold text-blue-900">
+                  {{ formattedBalance }}
+                </p>
+              </div>
+              <span class="flex h-11 w-11 items-center justify-center rounded-full bg-blue-500">
+                <svg width="26" height="26" viewBox="0 0 31 31" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    d="M15.5 31C24.0604 31 31 24.0604 31 15.5C31 6.93959 24.0604 0 15.5 0C6.93959 0 0 6.93959 0 15.5C0 24.0604 6.93959 31 15.5 31Z"
+                    fill="#ffffff" fill-opacity="0.12"
+                  />
+                  <rect width="31" height="31" rx="5.16667" fill="#3182CE" />
+                  <g clip-path="url(#clip0_254_14246_mobile)">
+                    <path
+                      d="M11.1068 11.3447H20.1889C20.295 11.3446 20.4009 11.3514 20.5062 11.3648C20.4705 11.1145 20.3845 10.8739 20.2533 10.6576C20.1222 10.4414 19.9486 10.2539 19.743 10.1066C19.5375 9.95924 19.3042 9.85505 19.0573 9.80029C18.8104 9.74553 18.5549 9.74134 18.3063 9.78798L10.8372 11.0632H10.8287C10.3599 11.1528 9.94294 11.4181 9.66309 11.8048C10.0847 11.5049 10.5894 11.344 11.1068 11.3447Z"
+                      fill="white"
+                    />
+                    <path
+                      d="M20.189 12.0273H11.1069C10.6254 12.0279 10.1636 12.2194 9.82312 12.5599C9.48259 12.9005 9.29105 13.3622 9.29053 13.8437V19.293C9.29105 19.7745 9.48259 20.2362 9.82312 20.5768C10.1636 20.9173 10.6254 21.1088 11.1069 21.1094H20.189C20.6705 21.1088 21.1322 20.9173 21.4728 20.5768C21.8133 20.2362 22.0048 19.7745 22.0054 19.293V13.8437C22.0048 13.3622 21.8133 12.9005 21.4728 12.5599C21.1322 12.2194 20.6705 12.0279 20.189 12.0273ZM18.8408 17.4766C18.6612 17.4766 18.4856 17.4233 18.3363 17.3235C18.1869 17.2237 18.0705 17.0819 18.0018 16.9159C17.933 16.75 17.9151 16.5674 17.9501 16.3912C17.9851 16.215 18.0716 16.0532 18.1987 15.9262C18.3257 15.7991 18.4875 15.7126 18.6637 15.6776C18.8398 15.6426 19.0224 15.6605 19.1884 15.7293C19.3544 15.798 19.4962 15.9144 19.596 16.0638C19.6958 16.2131 19.749 16.3887 19.749 16.5684C19.749 16.8092 19.6534 17.0402 19.483 17.2106C19.3127 17.3809 19.0817 17.4766 18.8408 17.4766Z"
+                      fill="white"
+                    />
+                    <path
+                      d="M9.30469 15.7585V12.9346C9.30469 12.3196 9.64526 11.2885 10.8273 11.0651C11.8306 10.877 12.824 10.877 12.824 10.877C12.824 10.877 13.4767 11.3311 12.9375 11.3311C12.3983 11.3311 12.4124 12.0264 12.9375 12.0264C13.4626 12.0264 12.9375 12.6934 12.9375 12.6934L10.8231 15.0916L9.30469 15.7585Z"
+                      fill="white"
+                    />
+                  </g>
+                  <defs>
+                    <clipPath id="clip0_254_14246_mobile">
+                      <rect width="14.5312" height="14.5312" fill="white" transform="translate(8.39648 8.39453)" />
+                    </clipPath>
+                  </defs>
+                </svg>
+              </span>
+            </div>
+          </div>
+        </nuxt-link>
         <nuxt-link :to="localePath({ name: 'index' })">
           <div @click="$store.commit('Media_Menu_Close', false)" class="nav-wrapper flex mt-6 items-center px-2 py-3">
             <div class="icon rounded-lg flex align-middle p-2 mr-5">
@@ -132,7 +180,77 @@
 </template>
 
 <script>
-export default {};
+export default {
+  data() {
+    return {
+      balance: 0,
+    };
+  },
+
+  computed: {
+    formattedBalance() {
+      return this.formatBalance(this.balance);
+    },
+  },
+
+  mounted() {
+    if (process.client) {
+      this.restoreBalance();
+      this.$root?.$on?.('update-header-balance', this.handleBalanceUpdate);
+    }
+  },
+
+  beforeDestroy() {
+    this.$root?.$off?.('update-header-balance', this.handleBalanceUpdate);
+  },
+
+  watch: {
+    '$auth.loggedIn'(value) {
+      if (!value) {
+        this.balance = 0;
+      } else if (process.client) {
+        this.restoreBalance();
+      }
+    },
+  },
+
+  methods: {
+    restoreBalance() {
+      if (!process.client) return;
+      const stored = window.localStorage.getItem('user_balance');
+      this.balance = stored ? Number(stored) || 0 : 0;
+    },
+
+    handleBalanceUpdate(payload) {
+      if (!payload) return;
+
+      let amount = null;
+      if (payload.balance !== undefined) {
+        amount = payload.balance;
+      } else if (payload.amount?.balance !== undefined) {
+        amount = payload.amount.balance;
+      } else if (typeof payload.amount === 'number') {
+        amount = payload.amount;
+      } else if (typeof payload === 'number') {
+        amount = payload;
+      }
+
+      if (amount !== null && amount !== undefined) {
+        this.balance = Number(amount) || 0;
+        if (process.client) {
+          window.localStorage.setItem('user_balance', String(this.balance));
+        }
+      }
+    },
+
+    formatBalance(value) {
+      const number = Number(value) || 0;
+      return number
+        .toFixed(0)
+        .replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+    },
+  },
+};
 </script>
 
 <style lang="scss" scoped>

--- a/pages/cabinet/index.vue
+++ b/pages/cabinet/index.vue
@@ -48,29 +48,29 @@
             <div class="flex flex-col items-center text-center">
               <!-- avatar -->
               <div
-                class="h-28  sm:h-36 rounded-xl overflow-hidden bg-blue-50 ring-1 ring-blue-100 flex items-center justify-center">
+                class="cabinet-avatar-wrapper w-28 h-28 sm:w-36 sm:h-36 rounded-full bg-blue-50 ring-1 ring-blue-100 flex items-center justify-center p-3 sm:p-4">
                 <!-- <img v-if="user.image != null" :src="avatar" alt="avatar" class="w-[50px] h-full" /> -->
                 <!-- placeholders (o'zgarishsiz) -->
                 <svg v-if="user.type == 1" width="106" height="122" viewBox="0 0 106 122"
-                  fill="none" xmlns="http://www.w3.org/2000/svg" class="scale-75 sm:scale-90">
+                  fill="none" xmlns="http://www.w3.org/2000/svg" class="cabinet-avatar-icon">
                   <path
                     d="M53 61C69.7281 61 83.2857 47.3465 83.2857 30.5C83.2857 13.6535 69.7281 0 53 0C36.2719 0 22.7143 13.6535 22.7143 30.5C22.7143 47.3465 36.2719 61 53 61ZM75.667 68.768L64.3571 114.375L56.7857 81.9688L64.3571 68.625H41.6429L49.2143 81.9688L41.6429 114.375L30.333 68.768C13.4629 69.5781 0 83.4699 0 100.65V110.562C0 116.877 5.08705 122 11.3571 122H94.6429C100.913 122 106 116.877 106 110.562V100.65C106 83.4699 92.537 69.5781 75.667 68.768Z"
                     fill="#3182CE" />
                 </svg>
                 <svg v-if="user.type == 2 && user.gender == 1" width="106" height="122"
-                  viewBox="0 0 106 122" fill="none" xmlns="http://www.w3.org/2000/svg" class="scale-75 sm:scale-90">
+                  viewBox="0 0 106 122" fill="none" xmlns="http://www.w3.org/2000/svg" class="cabinet-avatar-icon">
                   <path
                     d="M53 61C69.7281 61 83.2857 47.3465 83.2857 30.5C83.2857 13.6535 69.7281 0 53 0C36.2719 0 22.7143 13.6535 22.7143 30.5C22.7143 47.3465 36.2719 61 53 61ZM42.1871 72.4375C18.8813 72.4375 0 91.4523 0 114.923C0 118.831 3.14688 122 7.02723 122H98.9728C102.853 122 106 118.831 106 114.923C106 91.4523 87.1188 72.4375 63.813 72.4375H42.1871V72.4375Z"
                     fill="#3182CE" />
                 </svg>
                 <svg v-if="user.gender === null" width="106" height="122" viewBox="0 0 106 122"
-                  fill="none" xmlns="http://www.w3.org/2000/svg" class="scale-75 sm:scale-90">
+                  fill="none" xmlns="http://www.w3.org/2000/svg" class="cabinet-avatar-icon">
                   <path
                     d="M53 61C69.7281 61 83.2857 47.3465 83.2857 30.5C83.2857 13.6535 69.7281 0 53 0C36.2719 0 22.7143 13.6535 22.7143 30.5C22.7143 47.3465 36.2719 61 53 61ZM42.1871 72.4375C18.8813 72.4375 0 91.4523 0 114.923C0 118.831 3.14688 122 7.02723 122H98.9728C102.853 122 106 118.831 106 114.923C106 91.4523 87.1188 72.4375 63.813 72.4375H42.1871V72.4375Z"
                     fill="#3182CE" />
                 </svg>
                 <svg v-if="user.type == 2 && user.gender == 2" width="106" height="122"
-                  viewBox="0 0 106 122" xmlns="http://www.w3.org/2000/svg" class="scale-75 sm:scale-90">
+                  viewBox="0 0 106 122" xmlns="http://www.w3.org/2000/svg" class="cabinet-avatar-icon">
                   <path
                     d="M102.245 78.4389L76.6753 65.9629L65.863 60.6868C66.1341 60.5115 66.3921 60.3127 66.6582 60.1273H80.8552C81.911 60.1273 82.9235 59.6983 83.67 58.9347C84.4165 58.1711 84.8359 57.1354 84.8359 56.0555V45.3414H84.8C84.3657 30.4102 79.2959 17.2744 71.6823 9.03722C67.6673 4.40588 62.4636 1.2593 56.6427 0.319C56.3831 0.275576 56.1235 0.235492 55.8623 0.200419C55.5618 0.162005 55.263 0.123592 54.9593 0.0985393C54.3069 0.0363055 53.652 0.00342735 52.9967 0H52.9935C52.3436 0 51.7019 0.0384139 51.0619 0.0951992C50.7549 0.121922 50.4512 0.160334 50.1475 0.198748C49.8928 0.232151 49.6397 0.268894 49.3883 0.312318C43.6148 1.23592 38.447 4.33406 34.4435 8.8986C26.7563 17.1275 21.6311 30.325 21.1935 45.3431H21.1592V56.0572C21.1592 57.1371 21.5786 58.1728 22.3251 58.9364C23.0716 59.7 24.0841 60.129 25.1399 60.129H39.3761C39.7647 60.3996 40.1517 60.6751 40.5533 60.9223L30.1982 65.8543L3.79948 78.4306C1.50542 79.5296 0 82.1751 0 85.1296V114.8C0 118.777 2.70878 122 6.05434 122H99.9457C103.291 122 106 118.777 106 114.8V85.1263C105.998 82.1818 104.516 79.5613 102.245 78.4389Z"
                     fill="#3182CE" />
@@ -315,6 +315,24 @@ export default {
 </script>
 
 <style scoped>
+.cabinet-avatar-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cabinet-avatar-icon {
+  width: 70%;
+  height: auto;
+  max-height: 100%;
+}
+
+@media (min-width: 640px) {
+  .cabinet-avatar-icon {
+    width: 75%;
+  }
+}
+
 .modal__bg {
   position: fixed;
   width: 100vw;

--- a/pages/credit-list/index.vue
+++ b/pages/credit-list/index.vue
@@ -25,13 +25,13 @@
           </h2>
         </div>
        <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/return?type=creditor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class="w-full sm:w-auto grid grid-cols-2 gap-1 sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <button @click="sortModal = true"
@@ -159,7 +159,7 @@
           </div>
 
           <!-- Statlar -->
-          <div class="mt-2 grid grid-cols-2 gap-3">
+          <div class="mt-3 space-y-2">
             <div>
               <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
               <span
@@ -172,31 +172,6 @@
                     item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
                   }} {{ item.currency }}
                 </b>
-              </span>
-            </div>
-
-            <div>
-              <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-              <span
-                class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800"
-              >
-                <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                <b class="text-sm text-gray-900">
-                  {{
-                    item.residual_amount &&
-                    item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                  }} {{ item.currency }}
-                </b>
-              </span>
-            </div>
-
-            <div>
-              <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-              <span
-                class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800"
-              >
-                <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
               </span>
             </div>
 

--- a/pages/debt-list/index.vue
+++ b/pages/debt-list/index.vue
@@ -21,13 +21,13 @@
 
         <!-- Qidiruv + Harakat tugmalari (RESPONSIVE) -->
         <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/return?type=debitor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class="w-full sm:w-auto grid grid-cols-2 gap-1 sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <button @click="sortModal = true"
@@ -135,7 +135,7 @@
                   </nuxt-link>
                 </div>
 
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
@@ -145,27 +145,6 @@
                         {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{
                           item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">
-                        {{ item.residual_amount && item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
-                      </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
                     </span>
                   </div>
 

--- a/pages/expired-creditor/index.vue
+++ b/pages/expired-creditor/index.vue
@@ -31,13 +31,13 @@
         </div>
         <!-- Qidiruv + Harakat tugmalari (RESPONSIVE) -->
         <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/expired?status=${this.status}&type=creditor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class="w-full sm:w-auto grid grid-cols-2 gap-1 sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <button @click="sortModal = true"
@@ -153,41 +153,15 @@
                 </div>
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">
-                        {{
-                          item.residual_amount &&
-                          item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
-                      </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
                     </span>
                   </div>
 

--- a/pages/expired-debitor/index.vue
+++ b/pages/expired-debitor/index.vue
@@ -33,13 +33,13 @@
 
         <!-- Qidiruv + Harakat tugmalari (RESPONSIVE) -->
         <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/expired?status=${this.status}&type=debitor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class="w-full sm:w-auto grid grid-cols-2 gap-1 sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <button @click="sortModal = true"
@@ -158,41 +158,15 @@
 
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">
-                        {{
-                          item.residual_amount &&
-                          item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
-                      </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
                     </span>
                   </div>
 

--- a/pages/hisobot/creditor/index.vue
+++ b/pages/hisobot/creditor/index.vue
@@ -32,14 +32,14 @@
         </div>
         <!-- Qidiruv + Harakat tugmalari (RESPONSIVE) -->
         <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/report/search?status=${this.status}&type=creditor&page=${this.page + 1
             }&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class="w-full sm:w-auto grid grid-cols-2 gap-1 sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <button @click="sortModal = true"
@@ -66,7 +66,7 @@
         </div>
       </div>
 
-      <div class="tab-z">
+      <div class="tab-z hidden md:flex">
         <button class="tab-z-item" :class="{ __active: status == 'all' }" @click="changeStatus('all')">
           {{ $t('debt_list.total') }}
           <span class="count-z count-primary">{{ length }}</span>
@@ -168,40 +168,15 @@
                 </div>
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount
-                            .toString()
-                            .replace(/\B(?=(\d{3})+(?!\d))/g, " ")
-                        }}
-                        {{ item.currency }}
-
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.sana) }}</b>
                     </span>
                   </div>
 

--- a/pages/hisobot/debitor/index.vue
+++ b/pages/hisobot/debitor/index.vue
@@ -24,13 +24,13 @@
 
         <!-- Qidiruv + Harakat tugmalari (RESPONSIVE) -->
         <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts" :url="`/contract/report/search?status=${this.status}&type=debitor&page=${this.page + 1
               }&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class="w-full sm:w-auto grid grid-cols-2 gap-1 sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <button @click="sortModal = true"
@@ -57,7 +57,7 @@
         </div>
       </div>
 
-      <div class="tab-z">
+      <div class="tab-z hidden md:flex">
         <button class="tab-z-item" :class="{ __active: status == 'all' }" @click="changeStatus('all')">
           {{ $t("debt_list.total") }}
           <span class="count-z count-primary">{{ length }}</span>
@@ -157,40 +157,15 @@
                 </div>
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount
-                            .toString()
-                            .replace(/\B(?=(\d{3})+(?!\d))/g, " ")
-                        }}
-                        {{ item.currency }}
-
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.sana) }}</b>
                     </span>
                   </div>
 

--- a/pages/near-expiration-creditor-notification/index.vue
+++ b/pages/near-expiration-creditor-notification/index.vue
@@ -31,13 +31,13 @@
           </h2>
         </div>
        <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/near?type=creditor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class=" sm:w-auto sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <!-- Excel -->
@@ -143,41 +143,15 @@
                 </div>
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">
-                        {{
-                          item.residual_amount &&
-                          item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
-                      </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
                     </span>
                   </div>
 

--- a/pages/near-expiration-creditor/index.vue
+++ b/pages/near-expiration-creditor/index.vue
@@ -31,13 +31,13 @@
           </h2>
         </div>
           <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/near?type=creditor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class=" sm:w-auto sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <!-- Excel -->
@@ -144,41 +144,15 @@
                 </div>
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">
-                        {{
-                          item.residual_amount &&
-                          item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
-                      </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
                     </span>
                   </div>
 

--- a/pages/near-expiration-debitor/index.vue
+++ b/pages/near-expiration-debitor/index.vue
@@ -24,13 +24,13 @@
 
         <!-- Qidiruv + Harakat tugmalari (RESPONSIVE) -->
         <div class="p-5">
-          <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+          <div class="flex flex-col md:flex-row md:justify-between gap-3">
             <!-- Search to'liq kenglik -->
             <SearchComponent class="w-full pr-4 sm:flex-1" @searchData="searchData" :getContracts="getContracts"
               :url="`/contract/near?type=debitor&page=${this.page + 1}&limit=${this.limit}`" />
 
             <!-- Tugmalar: mobil’da qidiruv ostida yonma-yon -->
-            <div class=" sm:w-auto sm:grid-cols-none sm:flex sm:gap-2">
+            <div class="hidden md:flex md:w-auto md:gap-2">
               <!-- Filtr -->
 
               <!-- Excel -->
@@ -142,41 +142,15 @@
 
 
                 <!-- Statlar -->
-                <div class="mt-2 grid grid-cols-2 gap-3">
+                <div class="mt-3 space-y-2">
                   <div>
                     <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtsumm') }}</div>
                     <span
                       class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
                       <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
                       <b class="text-sm text-gray-900">
-                        {{
-                          item.amount &&
-                          item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
+                        {{ item.amount && item.amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') }} {{ item.currency }}
                       </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debta') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/$.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">
-                        {{
-                          item.residual_amount &&
-                          item.residual_amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-                        }} {{ item.currency }}
-                      </b>
-                    </span>
-                  </div>
-
-                  <div>
-                    <div class="text-[11px] text-gray-500">{{ $t('debt_list.debtol') }}</div>
-                    <span
-                      class="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-100 text-[12px] text-gray-800">
-                      <img src="@/assets/img/Date.png" class="w-3.5 h-3.5" alt="" />
-                      <b class="text-sm text-gray-900">{{ dateFormat(item.created_at) }}</b>
                     </span>
                   </div>
 


### PR DESCRIPTION
## Summary
- refine the logged-in mobile navigation panel and show the current balance shortcut on phones
- make the cabinet avatar circular with consistent spacing around the gender/company placeholders
- simplify mobile cards across debt, credit, expired, near-expiration, and report lists while hiding filter/export buttons on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb8f1002a48326a595c6e6f576ca7d